### PR TITLE
Allow setting host path with command line arguement, with environment variable and with roman config

### DIFF
--- a/apluslms_roman/builder.py
+++ b/apluslms_roman/builder.py
@@ -9,6 +9,7 @@ from .observer import StreamObserver
 from .utils.importing import import_string
 from .utils.translation import _
 
+
 class Builder:
     def __init__(self, engine, config, observer=None):
         if not isdir(config.dir):
@@ -21,7 +22,7 @@ class Builder:
 
     def get_steps(self, refs: list = None):
         steps = [BuildStep.from_config(i, step)
-            for i, step in enumerate(self.config.steps)]
+                 for i, step in enumerate(self.config.steps)]
         if refs:
             name_dict = {step.name: step for step in steps}
             refs = [int(ref) if ref.isdigit() else ref.lower() for ref in refs]
@@ -64,11 +65,9 @@ class Engine:
 
         name = getattr(backend_class, 'name', None) or backend_class.__name__.lower()
         env_prefix = name.upper() + '_'
-        env = {k: v for k, v in environ.items() if k.startswith(env_prefix)}
+        env = {key: value for key, value in environ.items() if key.startswith(env_prefix)}
         if settings:
-            for k, v in settings.get(name, {}).items():
-                if v is not None and v != '':
-                    env[env_prefix + k.replace('-', '_').upper()] = v
+            env.update(settings.get(name, {}))
         self._environment = Environment(getuid(), getegid(), env)
 
     @cached_property

--- a/apluslms_roman/schemas/roman_settings-v1.0.yaml
+++ b/apluslms_roman/schemas/roman_settings-v1.0.yaml
@@ -24,6 +24,10 @@ properties:
     type: object
     additionalProperties: false
     properties:
+      directory_map:
+        title: docker container-host machine path mapping
+        description: The dictornary mapping between docker and it's host
+        type: object
       host:
         title: docker host
         description: the URL to the Docker host

--- a/apluslms_roman/utils/path_mapping.py
+++ b/apluslms_roman/utils/path_mapping.py
@@ -1,0 +1,25 @@
+import json
+import logging
+import re
+from os import environ
+from apluslms_yamlidator.document import find_ml
+
+logger = logging.getLogger(__name__)
+json_re = re.compile(r'^(?:["[{]|(?:-?[1-9]\d*(?:\.\d+)?|null|true|false)$)')
+
+
+def nest_dict(flat_dict):
+    nested = {}
+    for keys, value in flat_dict.items():
+        dict_, key = find_ml(nested, keys, create_dicts=True)
+        dict_[key] = value
+    return nested
+
+
+def load_from_env(env_prefix=None, decode_json=True):
+    if decode_json:
+        decode = lambda s: json.loads(s) if json_re.match(s) is not None else s
+    else:
+        decode = lambda s: s
+    env = {key[len(env_prefix):].lower(): decode(value) for key, value in environ.items() if key.startswith(env_prefix)}
+    return nest_dict(env)

--- a/tests/utils/test_path_mapping.py
+++ b/tests/utils/test_path_mapping.py
@@ -1,0 +1,64 @@
+import os
+import unittest
+from json import loads
+
+from apluslms_roman.utils.path_mapping import json_re, load_from_env
+
+test_case_loadable = (
+    'true',
+    'false',
+    'null',
+    '123',
+    '-123',
+    '3.14',
+    '-3.14',
+    '{"foo": "bar"}',
+    '[1, 2, 3]',
+    '"foo bar"'
+)
+
+test_case_not_loadable = (
+    "/foobar.py",
+    "text",
+    "yes",
+    "0123123",
+)
+
+
+class TestJsonLoadable(unittest.TestCase):
+
+    def test_loadable_not_raise(self):
+        for case in test_case_loadable:
+            with self.subTest(non_json=case):
+                loads(case)
+
+    def test_not_loadable_raise(self):
+        for case in test_case_not_loadable:
+            with self.subTest(non_json=case):
+                with self.assertRaises(ValueError, msg="Testing:{}".format(case)):
+                    loads(case)
+
+
+class TestJsonRegex(unittest.TestCase):
+
+    def test_loadable_match(self):
+        for case in test_case_loadable:
+            with self.subTest(non_json=case):
+                self.assertTrue(json_re.match(case)is not None, msg="Testing:{}".format(case))
+
+    def test_not_loadable_not_match(self):
+        for case in test_case_not_loadable:
+            with self.subTest(non_json=case):
+                self.assertFalse(json_re.match(case) is not None, msg="Testing:{}".format(case))
+
+
+class TestLoadFromEnv(unittest.TestCase):
+
+    def test_with_decode_json(self):
+        os.environ['DOCKER.FOO.BAR'] = '123'
+        self.assertEqual({'foo': {'bar': '123'}}, load_from_env('DOCKER.', False))
+
+    def test_without_decode_json(self):
+        os.environ['DOCKER.FOO.BAR'] = '123'
+        self.assertEqual({'foo': {'bar': 123}}, load_from_env('DOCKER.', True))
+


### PR DESCRIPTION
Tell docker back-end the location of source file on host machine(if running  roman on a container)
The priority order is 
1. Global configure
2. Environment variable
3. Command line parament